### PR TITLE
Use updated Vineflower parameter names

### DIFF
--- a/versions/pre/1.20/1.20.5-pre1/config.json
+++ b/versions/pre/1.20/1.20.5-pre1/config.json
@@ -7,7 +7,7 @@
     "fernflower": {
         "version": "org.vineflower:vineflower:1.10.0",
         "java_version": 21,
-        "args": ["-din=1", "-rbr=1", "-dgs=1", "-asc=1", "-rsy=1", "-iec=1", "--variable-renaming=jad", "-iib=1", "-bsm=1", "-dcl=1", "-nls=1", "-ump=0", "-ind=    ", "-log=TRACE", "-cfg", "{libraries}", "{input}", "{output}"],
+        "args": ["--decompile-inner", "--remove-bridge", "--decompile-generics", "--ascii-strings", "--remove-synthetic", "--include-classpath", "--variable-renaming=jad", "--ignore-invalid-bytecode", "--bytecode-source-mapping", "--dump-code-lines", "--no-use-method-parameters", "--indent-string=    ", "--log-level=TRACE", "-cfg", "{libraries}", "{input}", "{output}"],
         "jvmargs": ["-Xmx4G"]
     },
     "merge": {


### PR DESCRIPTION
As of Vineflower 1.10, short flag names are deprecated in favor of the longer names. This PR replaces all short flags with their long equivalents, and it removes the now deprecated `nls` / "new line separator" flag, which defaults to using `\n` regardless of OS now, from the arguments list.