### PR TITLE
Add Gradle module metadata with dependency on Minecraft dependencies Gradle module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -865,7 +865,7 @@ subprojects {
         if (it.version) {
             dependencies.add('neoformData', it.version) { transitive = false }
         } else {
-            println("Skipping tool without version: $it")
+            println("Skipping tool in ${project.name} without version: $it")
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ plugins {
 
 import net.minecraftforge.mcpconfig.tasks.*
 import net.neoforged.srgutils.MinecraftVersion
+
+import javax.inject.Inject
 import java.nio.file.Files
 import java.util.function.BiFunction
 import java.util.stream.Collectors
@@ -24,6 +26,11 @@ ext {
 }
 
 logger.lifecycle('Timestamp: ' + TIMESTAMP)
+
+abstract class ComponentMaker {
+    @Inject
+    abstract SoftwareComponentFactory getComponentFactory()
+}
 
 task downloadVersionManifest(type: Download) {
     src 'https://launchermeta.mojang.com/mc/game/version_manifest_v2.json'
@@ -137,6 +144,13 @@ subprojects {
         maven {
             name 'forge'
             url 'https://maven.neoforged.net/releases'
+        }
+        maven {
+            name 'mojang meta'
+            url 'https://maven.neoforged.net/mojang-meta/'
+            content {
+                includeModule('net.neoforged', 'minecraft-dependencies')
+            }
         }
         for (tool in TOOLS) {
             if (tool.repo) {
@@ -799,12 +813,72 @@ subprojects {
         }
     }
 
+    def componentMaker = objects.newInstance(ComponentMaker)
+    def neoformComponent = componentMaker.componentFactory.adhoc('neoform')
+    components.add(neoformComponent)
+
+    configurations {
+        neoformData {
+            canBeResolved = false
+            attributes {
+                attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JAVA_TARGET)
+            }
+            outgoing {
+                capability "net.neoforged:neoform:${project.version + '-' + rootProject.TIMESTAMP}"
+            }
+            neoformComponent.addVariantsFromConfiguration(it) {}
+        }
+        neoformLibraries {
+            canBeResolved = false
+        }
+        neoformRuntimeElements {
+            canBeResolved = false
+            attributes {
+                attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JAVA_TARGET)
+                attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+            }
+            outgoing {
+                capability "net.neoforged:neoform-dependencies:${project.version + '-' + rootProject.TIMESTAMP}"
+            }
+            neoformComponent.addVariantsFromConfiguration(it) {}
+            extendsFrom neoformLibraries
+        }
+        neoformApiElements {
+            canBeResolved = false
+            attributes {
+                attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JAVA_TARGET)
+                attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+            }
+            outgoing {
+                capability "net.neoforged:neoform-dependencies:${project.version + '-' + rootProject.TIMESTAMP}"
+            }
+            neoformComponent.addVariantsFromConfiguration(it) {}
+            extendsFrom neoformLibraries
+        }
+    }
+
+    artifacts {
+        neoformData makeZip
+    }
+
+    TOOLS.each { dependencies.add('neoformData', it.version) { transitive = false } }
+
+    ['server', 'client', 'joined'].each {
+        CONFIG?.libraries?.get(it)?.each { dependencies.add('neoformApiElements', it) { transitive = false } }
+    }
+
+    dependencies {
+        neoformLibraries("net.neoforged:minecraft-dependencies:${project.version}") {
+            endorseStrictVersions()
+        }
+    }
+
     publishing {
         publications {
             timed(MavenPublication) {
                 artifactId rootProject.name
                 version project.version + '-' + rootProject.TIMESTAMP
-                artifact makeZip
+                from components.neoform
                 pom {
                     name = 'NeoForm'
                     description = 'Configuration files used for deobfuscating and modding Minecraft.'

--- a/build.gradle
+++ b/build.gradle
@@ -864,6 +864,8 @@ subprojects {
     TOOLS.each {
         if (it.version) {
             dependencies.add('neoformData', it.version) { transitive = false }
+        } else {
+            println("Skipping tool without version: $it")
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ subprojects {
         BUNDLE_EXTRACT_LIBS = null
         if (CONFIG.containsKey('bundler_extract_libs'))
             BUNDLE_EXTRACT_LIBS = Utils.readConfig(CONFIG, 'bundler_extract_libs', [:])
-        TOOLS = [FERNFLOWER, MERGETOOL, RENAMETOOL, MERGEMAPTOOL, MCINJECTOR, BUNDLE_EXTRACT_JAR, BUNDLE_EXTRACT_LIBS].findAll {it != null}
+        TOOLS = [FERNFLOWER, MERGETOOL, RENAMETOOL, MERGEMAPTOOL, MCINJECTOR, BUNDLE_EXTRACT_JAR, BUNDLE_EXTRACT_LIBS].findAll {it?.version != null}
     }
 
     java.toolchain.languageVersion = JavaLanguageVersion.of(JAVA_TARGET)
@@ -862,11 +862,7 @@ subprojects {
     }
 
     TOOLS.each {
-        if (it.version) {
-            dependencies.add('neoformData', it.version) { transitive = false }
-        } else {
-            println("Skipping tool in ${project.name} without version: $it")
-        }
+        dependencies.add('neoformData', it.version) { transitive = false }
     }
 
     ['server', 'client', 'joined'].each {

--- a/build.gradle
+++ b/build.gradle
@@ -861,7 +861,11 @@ subprojects {
         neoformData makeZip
     }
 
-    TOOLS.each { dependencies.add('neoformData', it.version) { transitive = false } }
+    TOOLS.each {
+        if (it.version) {
+            dependencies.add('neoformData', it.version) { transitive = false }
+        }
+    }
 
     ['server', 'client', 'joined'].each {
         CONFIG?.libraries?.get(it)?.each { dependencies.add('neoformApiElements', it) { transitive = false } }


### PR DESCRIPTION
This change introduces extensive Gradle module metadata to allow a Gradle plugin to depend on NeoForm and the transitive set of Minecraft libraries needed, without having to download NeoForm and parse its config during the Gradle configuration phase (this conflicts with the Gradle configuration cache feature).