### PR TITLE
Decompile fix: Horse dismount location searching

### DIFF
--- a/versions/release/1.21.7/patches/shared/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
+++ b/versions/release/1.21.7/patches/shared/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/animal/horse/AbstractHorse.java
++++ b/net/minecraft/world/entity/animal/horse/AbstractHorse.java
+@@ -983,7 +983,7 @@
+                 }
+ 
+                 blockpos$mutableblockpos.move(Direction.UP);
+-            } while (!(blockpos$mutableblockpos.getY() < d3));
++            } while (blockpos$mutableblockpos.getY() < d3);
+         }
+ 
+         return null;


### PR DESCRIPTION
This pull request fixes the horse dismount location searching condition, the while condition is unexpectedly inversed by VF, which may lead to an infinite loop and halt the server.

To reproduce:
- Summon a horse with command `/summon minecraft:horse ~ ~ ~ {attributes:[{base:0.1,id:"minecraft:scale"}],NoGravity:true,Tame:true,SaddleItem:{id:"minecraft:saddle"}}`
- Dig a 2 block deep hole below it
- Ride the horse and dismount it
- Server halts